### PR TITLE
Bug with running in production with Ruby Enterprise Edition

### DIFF
--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -15,14 +15,16 @@ module Crummy
         before_filter(options) do |instance|
           url = yield instance if block_given?
           url = instance.send url if url.is_a? Symbol
-          record = instance.instance_variable_get("@#{name}") unless url or block_given?
-          if record and record.respond_to? :to_param
-            name, url = record.to_s, instance.url_for(record)
+
+          _record = instance.instance_variable_get("@#{name}") unless url or block_given?
+          if _record and _record.respond_to? :to_param
+            instance.add_crumb(_record.to_s, instance.url_for(_record))
+          else 
+            instance.add_crumb(name, url)
           end
         
           # FIXME: url = instance.url_for(name) if name.respond_to?("to_param") && url.nil?
           # FIXME: Add ||= for the name, url above
-          instance.add_crumb(name, url)
         end
       end
     end


### PR DESCRIPTION
I think I went crazy till I traced this down, for some odd caching reason, the program works fine in vanilla Ruby (dev & prod) and in Ruby Enterprise Edition (dev only).  If you run it as production, the breadcrumbs for a specific path are never changed for symbols

In our case, the server name (#to_s method on our server model) would never change and remain on the one in the original load.  We have a sample application here.

https://github.com/mnaser/crummy_bug

You can clone that, make sure you rake db:migrate and then create 3-4 records, run the server in production (it's configured to use same dev db) and open a post entry, then go back and open another one, you'll notice the links are frozen and no matter what happens they'll never change!

Rails has some weird class stuff.  This fixes it and we tested it and run it in production too.  Fantastic gem, we gotta work on tests.
