### PR TITLE
Allow name to be a proc or lambda method

### DIFF
--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -4,6 +4,7 @@ module Crummy
       # Add a crumb to the crumbs array.
       #
       #   add_crumb("Home", "/")
+      #   add_crumb(lambda { |instance| instance.business_name }, "/")
       #   add_crumb("Business") { |instance| instance.business_path }
       #
       # Works like a before_filter so +:only+ and +except+ both work.
@@ -15,6 +16,9 @@ module Crummy
         before_filter(options) do |instance|
           url = yield instance if block_given?
           url = instance.send url if url.is_a? Symbol
+
+          # Get the return value of the name if its a proc.
+          name = name.call(instance) if name.is_a?(Proc)
 
           _record = instance.instance_variable_get("@#{name}") unless url or block_given?
           if _record and _record.respond_to? :to_param


### PR DESCRIPTION
Hello!

I took the crummy gem for a spin in a project here to handle my breadcrumbs, and needed some way to dynamically assign the name of a breadcrumb element.

I noticed in the todolist for the project that you wanted to implement some way of using varirables in names, so I made a simple change to the code to allow the name attribute for add_crumb to be a proc or lambda method that will be called in the before_filter together with the rest of the crummy-code.
