### PR TITLE
Allow name to be a proc or lambda method

### DIFF
--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -4,6 +4,7 @@ module Crummy
       # Add a crumb to the crumbs array.
       #
       #   add_crumb("Home", "/")
+      #   add_crumb(lambda { |instance| instance.business_name }, "/")
       #   add_crumb("Business") { |instance| instance.business_path }
       #
       # Works like a before_filter so +:only+ and +except+ both work.
@@ -16,11 +17,14 @@ module Crummy
           url = yield instance if block_given?
           url = instance.send url if url.is_a? Symbol
 
-          _record = instance.instance_variable_get("@#{name}") unless url or block_given?
+          # Get the return value of the name if its a proc.
+          transformed_name = name.is_a?(Proc) ? name.call(instance) : name
+
+          _record = instance.instance_variable_get("@#{transformed_name}") unless url or block_given?
           if _record and _record.respond_to? :to_param
             instance.add_crumb(_record.to_s, instance.url_for(_record))
           else 
-            instance.add_crumb(name, url)
+            instance.add_crumb(transformed_name, url)
           end
         
           # FIXME: url = instance.url_for(name) if name.respond_to?("to_param") && url.nil?


### PR DESCRIPTION
This is a fix for bugged pull request #13.

> Hello!
> 
> I took the crummy gem for a spin in a project here to handle my breadcrumbs, and needed some way to dynamically assign the name of a breadcrumb element.
> 
> I noticed in the todolist for the project that you wanted to implement some way of using varirables in names, so I made a simple change to the code to allow the name attribute for add_crumb to be a proc or lambda method that will be called in the before_filter together with the rest of the crummy-code.
