### PR TITLE
Pull Request for clear crumbs as before filter

### DIFF
--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -27,6 +27,12 @@ module Crummy
           # FIXME: Add ||= for the name, url above
         end
       end
+
+      def clear_crumbs
+        before_filter do |instance|
+          instance.clear_crumbs
+        end
+      end
     end
 
     module InstanceMethods
@@ -37,6 +43,10 @@ module Crummy
       #
       def add_crumb(name, url=nil)
         crumbs.push [name, url]
+      end
+
+      def clear_crumbs
+        crumbs.clear
       end
 
       # Lists the crumbs as an array


### PR DESCRIPTION
Hello,

I just fork and commit to add method 'clear_crumbs' to clear crumbs items.

target usage: namespaced application_controller

ApplicationController
  |- namespace
    |- Namespace::ApplicationController < ApplicationController

First, add_crumbs in the ApplicationController of root-directory
Second, also add_crumbs in the ApplicaitonController of namespaced directory, but its crumbs required to clear and add.
then use clear_crumbs before add_crumbs

Best regards.
