### PR TITLE
Allow breadcrumb titles containing spaces

### DIFF
--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -29,7 +29,7 @@ module Crummy
           # Get the return value of the name if its a proc.
           transformed_name = name.is_a?(Proc) ? name.call(instance) : name
 
-          _record = instance.instance_variable_get("@#{transformed_name}")
+          _record = instance.instance_variable_get("@#{transformed_name}") rescue nil
           if _record and _record.respond_to? :to_param
             instance.add_crumb(_record.to_s, url || instance.url_for(_record))
           else 


### PR DESCRIPTION
Prevent NameError when passing a string containing spaces as the breadcrumb name.
