### PR TITLE
:li_class fixed in StandardRenderer#crumb_to_html_list

### DIFF
--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -81,6 +81,7 @@ module Crummy
       html_classes << first_class if is_first
       html_classes << last_class if is_last
       html_classes << active_li_class unless url && links
+      html_classes << li_class if !is_first && !is_last && url && links
       url && links ? "<li class=\"#{html_classes.join(' ').strip}\"><a href=\"#{url}\">#{name}</a></li>" : "<li class=\"#{html_classes.join(' ').strip}\"><span>#{name}</span></li>"
     end
   

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -21,8 +21,8 @@ class StandardRendererTest < Test::Unit::TestCase
 
     assert_equal('<a href="url1" class="first">name1</a> &raquo; <a href="url2" class="last">name2</a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html))
-    assert_equal('<ul class="" id=""><li class="first"><a href="url1">name1</a></li><li class="last"><a href="url2">name2</a></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html_list))
+    assert_equal('<ul class="" id=""><li class="first"><a href="url1">name1</a></li><li class="li_class"><a href="url2">name2</a></li><li class="last"><a href="url3">name3</a></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list))
     assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :xml))
   end


### PR DESCRIPTION
With the addition of the `:first_class` and `:last_class` options, the `:li_class` option is now ignored in the StandardRenderer#crumb_to_html_list method. Fixed this in standard_renderer.rb and modified the test to check for this functionality.
