### PR TITLE
Last breadcrumb set as not linked

### DIFF
--- a/lib/crummy.rb
+++ b/lib/crummy.rb
@@ -21,6 +21,7 @@ module Crummy
     attr_accessor :ul_class
     attr_accessor :li_class
     attr_accessor :microdata
+    attr_accessor :last_crumb_linked
 
     def initialize
       @format = :html
@@ -35,6 +36,7 @@ module Crummy
       @ul_class = ''
       @li_class = ''
       @microdata = false
+      @last_crumb_linked = true
     end
 
     def active_li_class=(class_name)

--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -36,11 +36,12 @@ module Crummy
       options[:first_class] ||= Crummy.configuration.first_class
       options[:last_class] ||= Crummy.configuration.last_class
       options[:microdata] ||= Crummy.configuration.microdata
+      options[:last_crumb_linked] = Crummy.configuration.last_crumb_linked if options[:last_crumb_linked].nil?
 
       case options[:format]
       when :html
         crumb_string = crumbs.collect do |crumb|
-          crumb_to_html(crumb, options[:links], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata])
+          crumb_to_html(crumb, options[:links], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata], options[:last_crumb_linked])
         end.reduce { |memo, obj| memo << options[:separator] << obj }
         crumb_string
       when :html_list
@@ -49,7 +50,7 @@ module Crummy
         options[:ul_class] ||= Crummy.configuration.ul_class
         options[:ul_id] ||= Crummy.configuration.ul_id
         crumb_string = crumbs.collect do |crumb|
-          crumb_to_html_list(crumb, options[:links], options[:li_class], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata])
+          crumb_to_html_list(crumb, options[:links], options[:li_class], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata], options[:last_crumb_linked])
         end.reduce { |memo, obj| memo << options[:separator] << obj }
         crumb_string = content_tag(:ul, crumb_string, :class => options[:ul_class], :id => options[:ul_id])
         crumb_string
@@ -64,12 +65,12 @@ module Crummy
 
     private
 
-    def crumb_to_html(crumb, links, first_class, last_class, is_first, is_last, with_microdata)
+    def crumb_to_html(crumb, links, first_class, last_class, is_first, is_last, with_microdata, last_crumb_linked)
       html_classes = []
       html_classes << first_class if is_first
       html_classes << last_class if is_last
       name, url = crumb
-      can_link = url && links && !is_last
+      can_link = url && links && (!is_last || last_crumb_linked)
       html_content = can_link ? link_to(name, url) : content_tag(:span, name)
       if with_microdata
         item_title = content_tag(:span, name, :itemprop => "title")
@@ -81,9 +82,9 @@ module Crummy
       end
     end
     
-    def crumb_to_html_list(crumb, links, li_class, first_class, last_class, is_first, is_last, with_microdata)
+    def crumb_to_html_list(crumb, links, li_class, first_class, last_class, is_first, is_last, with_microdata, last_crumb_linked)
       name, url = crumb
-      can_link = url && links && !is_last
+      can_link = url && links && (!is_last || last_crumb_linked)
       html_classes = []
       html_classes << first_class if is_first
       html_classes << last_class if is_last

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -36,6 +36,32 @@ class StandardRendererTest < Test::Unit::TestCase
     assert_equal('<ul class="crumbclass" id="crumbid"><li class="liclass"><a href="url">name</a></li></ul>',
                  renderer.render_crumbs([['name', 'url']], :format => :html_list, :ul_id => "crumbid", :ul_class => "crumbclass", :li_class => "liclass"))
   end
+ 
+  def test_classes_last_crumb_not_linked
+    renderer = StandardRenderer.new
+    assert_equal('name',
+                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))  
+    assert_equal('<ul class="" id=""><li class="first last"><span>name</span></li></ul>',
+                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
+    assert_equal('<crumb href="url">name</crumb>',
+                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :xml, :last_crumb_linked => false))
+
+    assert_equal('<a href="url1" class="first">name1</a> &raquo; name2',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
+    assert_equal('<ul class="" id=""><li class="first li_class"><a href="url1">name1</a></li><li class="li_class"><a href="url2">name2</a></li><li class="last li_class"><span>name3</span></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
+    assert_equal('<ul class="" id=""><li class="first li_class"><a href="url1">name1</a></li> / <li class="li_class"><a href="url2">name2</a></li> / <li class="last li_class"><span>name3</span></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list, :separator => " / ", :last_crumb_linked => false))
+    assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :xml, :last_crumb_linked => false))
+
+    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></div>',
+                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :microdata => true, :last_crumb_linked => false))
+    assert_equal('<ul class="" id=""><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></li></ul>',
+                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list, :microdata => true, :last_crumb_linked => false))
+    assert_equal('<ul class="crumbclass" id="crumbid"><li class="liclass"><span>name</span></li></ul>',
+                 renderer.render_crumbs([['name', 'url']], :format => :html_list, :ul_id => "crumbid", :ul_class => "crumbclass", :li_class => "liclass", :last_crumb_linked => false))
+  end
 
   def test_configuration
     renderer = StandardRenderer.new
@@ -69,5 +95,7 @@ class StandardRendererTest < Test::Unit::TestCase
     # using configured microdata setting
     assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html))
-  end
+    # last crumb not linked
+    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></div>',
+                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))  end
 end


### PR DESCRIPTION
Added "can_link" param to verify if current breadcrumb must be linked (see methods: crumb_to_html, crumb_to_html_list).

I've done it because in my web project last breadcrumb is connected with visited page. In this case breadcrumb should not be linked.

Well, it's not perfect solution. I would like to have method that checks this condition automatically with using "current_page?" helper method.

It's hard to do now because context is required. For details how to do that see "breadcrumbs_on_rails" gem.

Thank you.
