### PR TITLE
Use assert_dom_equal instead of assert_equal

### DIFF
--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -15,14 +15,14 @@ class StandardRendererTest < Test::Unit::TestCase
 
   def test_classes
     renderer = StandardRenderer.new
-    assert_equal('<a href="url" class="first last">name</a>',
+    assert_dom_equal('<a href="url" class="first last">name</a>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html))
     assert_equal('<ul class="" id=""><li class="first last"><a href="url">name</a></li></ul>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list))
     assert_equal('<crumb href="url">name</crumb>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :xml))
 
-    assert_equal('<a href="url1" class="first">name1</a> &raquo; <a href="url2" class="last">name2</a>',
+    assert_dom_equal('<a href="url1" class="first">name1</a> &raquo; <a href="url2" class="last">name2</a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html))
     assert_equal('<ul class="" id=""><li class="first li_class"><a href="url1">name1</a></li><li class="li_class"><a href="url2">name2</a></li><li class="last li_class"><a href="url3">name3</a></li></ul>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list))
@@ -31,7 +31,7 @@ class StandardRendererTest < Test::Unit::TestCase
     assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :xml))
 
-    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
+    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :microdata => true))
     assert_equal('<ul class="" id=""><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" itemprop="url"><span itemprop="title">name</span></a></li></ul>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list, :microdata => true))
@@ -48,7 +48,7 @@ class StandardRendererTest < Test::Unit::TestCase
     assert_equal('<crumb href="url">name</crumb>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :xml, :last_crumb_linked => false))
 
-    assert_equal('<a href="url1" class="first">name1</a> &raquo; name2',
+    assert_dom_equal('<a href="url1" class="first">name1</a> &raquo; name2',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
     assert_equal('<ul class="" id=""><li class="first li_class"><a href="url1">name1</a></li><li class="li_class"><a href="url2">name2</a></li><li class="last li_class"><span>name3</span></li></ul>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
@@ -82,10 +82,10 @@ class StandardRendererTest < Test::Unit::TestCase
       config.html_separator = " / "
     end
     # using configured separator
-    assert_equal('<a href="url1" class="">name1</a> / <a href="url2" class="">name2</a>',
+    assert_dom_equal('<a href="url1" class="">name1</a> / <a href="url2" class="">name2</a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']]))
     # overriding configured separator
-    assert_equal('<a href="url1" class="">name1</a> | <a href="url2" class="">name2</a>',
+    assert_dom_equal('<a href="url1" class="">name1</a> | <a href="url2" class="">name2</a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :separator => " | "))
   end
 
@@ -95,7 +95,7 @@ class StandardRendererTest < Test::Unit::TestCase
       config.microdata = true
     end
     # using configured microdata setting
-    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
+    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
                  renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html))
     # last crumb not linked
     assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></div>',


### PR DESCRIPTION
Order of attribute is not specified in rails4(why? I don't know yet),
so I use `assert_dom_equal`
(implemented in `actionpack/lib/action_dispatch/testing/assertions/dom.rb`)
instead of `assert_equal`.
