### PR TITLE
Fix duplicate breadcrumbs

### DIFF
--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -41,9 +41,11 @@ module Crummy
 
       case options[:format]
       when :html
-        crumb_string = crumbs.collect do |crumb|
-          crumb_to_html(crumb, options[:links], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata], options[:last_crumb_linked], options[:truncate])
-        end.reduce { |memo, obj| memo << options[:separator] << obj }
+        crumb_string = ''.html_safe
+        crumbs.each_with_index do |crumb, index|
+          crumb_string << options[:separator] unless(index == 0)
+          crumb_string << crumb_to_html(crumb, options[:links], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata], options[:last_crumb_linked], options[:truncate])
+        end
         crumb_string
       when :html_list
         # Let's set values for special options of html_list format
@@ -52,9 +54,10 @@ module Crummy
         options[:ul_id] ||= Crummy.configuration.ul_id
         options[:ul_id] = nil if options[:ul_id].blank?
 
-        crumb_string = crumbs.collect do |crumb|
-          crumb_to_html_list(crumb, options[:links], options[:li_class], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata], options[:last_crumb_linked], options[:truncate], options[:separator])
-        end.reduce { |memo, obj| memo << obj }
+        crumb_string = ''.html_safe
+        crumbs.each do |crumb|
+          crumb_string << crumb_to_html_list(crumb, options[:links], options[:li_class], options[:first_class], options[:last_class], (crumb == crumbs.first), (crumb == crumbs.last), options[:microdata], options[:last_crumb_linked], options[:truncate], options[:separator])
+        end
         crumb_string = content_tag(:ul, crumb_string, :class => options[:ul_class], :id => options[:ul_id])
         crumb_string
       when :xml

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -65,6 +65,26 @@ class StandardRendererTest < Test::Unit::TestCase
                  renderer.render_crumbs([['name', 'url']], :format => :html_list, :ul_id => "crumbid", :ul_class => "crumbclass", :li_class => "liclass", :last_crumb_linked => false))
   end
 
+  def test_input_object_mutation
+    renderer = StandardRenderer.new
+    Crummy.configure do |config|
+      config.microdata = false
+    end
+
+    name1 = 'name1'
+    url1 = nil
+    name2 = 'name2'
+    url2 = nil
+
+    renderer.render_crumbs([[name1, url1], [name2, url2]], :format => :html, :microdata => false)
+
+    # Rendering the crumbs shouldn't alter the input objects.
+    assert_equal('name1', name1);
+    assert_equal(nil, url2);
+    assert_equal('name2', name2);
+    assert_equal(nil, url2);
+  end
+
   def test_link_html_options
     renderer = StandardRenderer.new
     Crummy.configure do |config|


### PR DESCRIPTION
In the event the first breadcrumb's name wasn't linked, that breadcrumb's name object was mutated into the full breadcrumb result. On subsequent render calls, duplicate breadcrumbs would appear since the
first item's name now contained the full breadcrumb result.

This should fix #45
