### PR TITLE
Fix the micodata option when set as a direct option of render_crumbs

### DIFF
--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -35,7 +35,7 @@ module Crummy
       options[:links] ||= Crummy.configuration.links
       options[:first_class] ||= Crummy.configuration.first_class
       options[:last_class] ||= Crummy.configuration.last_class
-      options[:microdata] ||= Crummy.configuration.microdata
+      options[:microdata] ||= Crummy.configuration.microdata if options[:microdata].nil?
       options[:truncate] ||= Crummy.configuration.truncate if options[:truncate]
       options[:last_crumb_linked] = Crummy.configuration.last_crumb_linked if options[:last_crumb_linked].nil?
 

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -103,6 +103,25 @@ class StandardRendererTest < Test::Unit::TestCase
                  renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
   end
 
+  def test_inline_configuration
+    renderer = StandardRenderer.new
+    Crummy.configure do |config|
+      config.microdata = true
+      config.last_crumb_linked = true
+    end
+
+    assert_no_match(/itemscope/, renderer.render_crumbs([['name', 'url']], :microdata => false))
+    assert_match(/href/, renderer.render_crumbs([['name', 'url']], :last_crumb_linked => true))
+
+    Crummy.configure do |config|
+      config.microdata = false
+      config.last_crumb_linked = true
+    end
+
+    assert_match(/itemscope/, renderer.render_crumbs([['name', 'url']], :microdata => true))
+    assert_no_match(/href/, renderer.render_crumbs([['name', 'url']], :last_crumb_linked => false))
+  end
+
   def test_configuration
     renderer = StandardRenderer.new
     # check defaults


### PR DESCRIPTION
If `Crummy.configuration.microdata` is set to true, passing in `:microdata => false` to `render_crumbs` will currently have no effect (due to the `||=` semantics). This fixes that issues and adds some tests around the boolean options.
