### PR TITLE
Simplify and improve Crummy::StandardRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,18 @@ add_crumb "<span class="fa fa-life-ring"></span> Support", "/", escape: false
 
 `render_crumbs` renders the list of crumbs as either html or xml
 
-The output format. Can either be :xml or :html or :html\_list. Defaults
+The output format. Can either be :xml or :html. Defaults
 to :html
 
 ```ruby
-format: (:html|:html_list|:xml)
+format: (:html|:xml)
+```
+
+Unordered lists and other such structures can be created by specifying :container and :wrap_with.
+The following would output an unordered list:
+
+```ruby
+render_crumbs container: :ul, wrap_with: :li, separator: ''
 ```
 
 The separator text. It does not assume you want spaces on either side so
@@ -154,8 +161,6 @@ Possible parameters for configuration are:
 :html_right_to_left_separator
 :xml_separator
 :xml_right_to_left_separator
-:html_list_separator
-:html_list_right_to_left_separator
 :default_crumb_class
 :crumb_first_class
 :crumb_last_class

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Possible parameters for configuration are:
 :right_to_left
 :crumb_html
 :crumb_xml
+:microdata
 ```
 
 See `lib/crummy.rb` for a list of these parameters and their defaults.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Crummy is a simple and tasty way to add breadcrumbs to your Rails applications.
 Simply add the dependency to your Gemfile:
 
 ```ruby
-gem "crummy", "~> 1.8.0"
+gem "crummy", github: 'blaknite/crummy', branch: 'master'
 ```
 
 # Example
@@ -27,7 +27,7 @@ end
 class BusinessController < ApplicationController
   add_crumb("Businesses") { |instance| instance.send :businesses_path }
   add_crumb("Comments", only: "comments") { |instance| instance.send :businesses_comments_path }
-  before_filter :load_comment, only: "show"
+  before_action :load_comment, only: "show"
   add_crumb :comment, only: "show"
 
   # Example for nested routes:
@@ -51,18 +51,18 @@ Then in your view:
 
 ## Html options for breadcrumb link
 
-You can set the html options with *link_html_options*.
-These are added to the *a* tag.
+You can set the html options with `:crumb_html`.
+These are added to the `<a>` or `<li>` tag.
 
 ```ruby
-add_crumb "Home", '/', link_html_options: {title: "my link title"}
+add_crumb "Home", '/', crumb_html: { title: "my link title" }
 ```
 
 ##You can set html instead text in first parameter.
-If tag <code>a</code> present in this html, tag a not be a wrapper.
+You must tell specify that the string is not to be escaped. For example if you want to use icons in your crumbs:
 
 ```ruby
-add_crumb "<a class='glyphicons shield' href='/support'><i></i>Support</a>".html_safe, "", {}
+add_crumb "<span class="fa fa-life-ring"></span> Support", "/", escape: false
 ```
 
 ## Options for render\_crumbs
@@ -87,21 +87,13 @@ separator: string
 Render links in the output. Defaults to *true*
 
 ```ruby
-links: false
-```
-
-Render
-[Richsnipet](http:/support.google.com/webmasters/bin/answer.py?hl=en&answer=99170&topic=1088472&ctx=topic/)
-Default to *false*
-
-```ruby
-microdata: true
+render_with_links: false
 ```
 
 Optionally disable linking of the last crumb, Defaults to *true*
 
 ```ruby
-last_crumb_linked: false
+link_last_crumb: false
 ```
 
 With this option, output will be blank if there are no breadcrumbs.
@@ -131,7 +123,7 @@ add_crumb support_link, {:right_side => true, :links => "/support", :li_right_cl
 
 A crumb with a nil argument for the link will output an unlinked crumb.
 
-With `format: :html_list` you can specify additional `params: :li_class, :ul_class, :ul_id`
+With `format: :html_list` you can specify the additional option `:container_class`
 
 ### App-wide configuration
 
@@ -156,36 +148,32 @@ Possible parameters for configuration are:
 
 ```ruby
 :format
-:links
+:render_with_links
 :skip_if_blank
 :html_separator
+:html_right_to_left_separator
 :xml_separator
+:xml_right_to_left_separator
 :html_list_separator
-:html_list_right_separator
-:first_class
-:last_class
-:ul_id
-:ul_class
-:li_class
-:li_right_class
-:microdata
-:last_crumb_linked
+:html_list_right_to_left_separator
+:default_crumb_class
+:crumb_first_class
+:crumb_last_class
+:container_class
+:link_last_crumb
 :truncate
-:right_side
+:escape
+:right_to_left
+:crumb_html
 ```
 
 See `lib/crummy.rb` for a list of these parameters and their defaults.
 
 ###Individually for each crumb configuration:
 ```ruby
-add_crumb support_link, {:right_side => true, :links => "/support", : li_class => "my_class", :li_right_class => "pull-right hidden-phone"}
+add_crumb 'Support', support_path, crumb_html: { class: 'important', title: 'File a support request.' }, truncate: 20
 ```
-Simple add that parameter to options hash. 
-
-
-## Live example application
-
-An example application is available right inside this gem. That application is documented, see `example/README` for details about usage.
+Simple add that parameter to options hash.
 
 ## Todo
 
@@ -216,5 +204,6 @@ An example application is available right inside this gem. That application is d
 -   [Jan Szumiec](http://github.com/jasiek)
 -   [Jeff Browning](http://github.com/jbrowning)
 -   [Bill Turner](http://github.com/billturner)
+-   [Grant Colegate](http://github.com/blaknite)
 
 **Copyright 2008-2013 Zach Inglis, released under the MIT license**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 class BusinessController < ApplicationController
   add_crumb("Businesses") { |instance| instance.send :businesses_path }
   add_crumb("Comments", only: "comments") { |instance| instance.send :businesses_comments_path }
-  before_action :load_comment, only: "show"
+  before_filter :load_comment, only: "show"
   add_crumb :comment, only: "show"
 
   # Example for nested routes:

--- a/lib/crummy.rb
+++ b/lib/crummy.rb
@@ -13,10 +13,8 @@ module Crummy
     attr_accessor :right_to_left
     attr_accessor :render_with_links
     attr_accessor :skip_if_blank
-    attr_accessor :html_separator
-    attr_accessor :html_right_to_left_separator
-    attr_accessor :xml_separator
-    attr_accessor :xml_right_to_left_separator
+    attr_accessor :separator
+    attr_accessor :right_to_left_separator
     attr_accessor :default_crumb_class
     attr_accessor :container_class
     attr_accessor :first_crumb_class
@@ -25,16 +23,15 @@ module Crummy
     attr_accessor :truncate
     attr_accessor :escape
     attr_accessor :crumb_html
+    attr_accessor :crumb_xml
     attr_accessor :container
     attr_accessor :wrap_with
 
     def initialize
       @format = :html
       @right_to_left = false
-      @html_separator = " &raquo; ".html_safe
-      @html_right_to_left_separator = " &laquo; ".html_safe
-      @xml_separator = 'crumb'
-      @xml_right_to_left_separator = 'crumb'
+      @separator = " &raquo; ".html_safe
+      @right_to_left_separator = " &laquo; ".html_safe
       @skip_if_blank = true
       @render_with_links = true
       @default_crumb_class = ''
@@ -45,6 +42,7 @@ module Crummy
       @truncate = nil
       @escape = true
       @crumb_html = {}
+      @crumb_xml = {}
       @container = nil
       @wrap_with = nil
     end

--- a/lib/crummy.rb
+++ b/lib/crummy.rb
@@ -17,8 +17,6 @@ module Crummy
     attr_accessor :html_right_to_left_separator
     attr_accessor :xml_separator
     attr_accessor :xml_right_to_left_separator
-    attr_accessor :html_list_separator
-    attr_accessor :html_list_right_to_left_separator
     attr_accessor :default_crumb_class
     attr_accessor :container_class
     attr_accessor :first_crumb_class
@@ -27,6 +25,8 @@ module Crummy
     attr_accessor :truncate
     attr_accessor :escape
     attr_accessor :crumb_html
+    attr_accessor :container
+    attr_accessor :wrap_with
 
     def initialize
       @format = :html
@@ -35,8 +35,6 @@ module Crummy
       @html_right_to_left_separator = " &laquo; ".html_safe
       @xml_separator = 'crumb'
       @xml_right_to_left_separator = 'crumb'
-      @html_list_separator = ''
-      @html_list_right_to_left_separator = ''
       @skip_if_blank = true
       @render_with_links = true
       @default_crumb_class = ''
@@ -47,6 +45,8 @@ module Crummy
       @truncate = nil
       @escape = true
       @crumb_html = {}
+      @container = nil
+      @wrap_with = nil
     end
   end
 

--- a/lib/crummy.rb
+++ b/lib/crummy.rb
@@ -25,6 +25,7 @@ module Crummy
     attr_accessor :crumb_xml
     attr_accessor :container
     attr_accessor :wrap_with
+    attr_accessor :microdata
 
     def initialize
       @format = :html
@@ -43,6 +44,7 @@ module Crummy
       @crumb_xml = {}
       @container = nil
       @wrap_with = nil
+      @microdata = false
     end
   end
 

--- a/lib/crummy.rb
+++ b/lib/crummy.rb
@@ -11,7 +11,7 @@ module Crummy
   class Configuration
     attr_accessor :format
     attr_accessor :right_to_left
-    attr_accessor :render_with_links
+    attr_accessor :link
     attr_accessor :skip_if_blank
     attr_accessor :separator
     attr_accessor :right_to_left_separator
@@ -31,9 +31,8 @@ module Crummy
       @format = :html
       @right_to_left = false
       @separator = " &raquo; ".html_safe
-      @right_to_left_separator = " &laquo; ".html_safe
       @skip_if_blank = true
-      @render_with_links = true
+      @link = true
       @default_crumb_class = ''
       @container_class = ''
       @first_crumb_class = ''

--- a/lib/crummy.rb
+++ b/lib/crummy.rb
@@ -10,51 +10,43 @@ module Crummy
 
   class Configuration
     attr_accessor :format
-    attr_accessor :links
+    attr_accessor :right_to_left
+    attr_accessor :render_with_links
     attr_accessor :skip_if_blank
     attr_accessor :html_separator
-    attr_accessor :html_right_separator
+    attr_accessor :html_right_to_left_separator
     attr_accessor :xml_separator
-    attr_accessor :xml_right_separator
+    attr_accessor :xml_right_to_left_separator
     attr_accessor :html_list_separator
-    attr_accessor :html_list_right_separator
-    attr_accessor :first_class
-    attr_accessor :last_class
-    attr_accessor :ul_id
-    attr_accessor :ul_class
-    attr_accessor :li_class
-    attr_accessor :microdata
-    attr_accessor :last_crumb_linked
+    attr_accessor :html_list_right_to_left_separator
+    attr_accessor :default_crumb_class
+    attr_accessor :container_class
+    attr_accessor :first_crumb_class
+    attr_accessor :last_crumb_class
+    attr_accessor :link_last_crumb
     attr_accessor :truncate
-    attr_accessor :right_side
+    attr_accessor :escape
+    attr_accessor :crumb_html
 
     def initialize
       @format = :html
+      @right_to_left = false
       @html_separator = " &raquo; ".html_safe
-      @html_right_separator = " &raquo; ".html_safe
-      @xml_separator = "crumb"
-      @xml_right_separator = "crumb"
+      @html_right_to_left_separator = " &laquo; ".html_safe
+      @xml_separator = 'crumb'
+      @xml_right_to_left_separator = 'crumb'
       @html_list_separator = ''
-      @html_list_right_separator = ''
+      @html_list_right_to_left_separator = ''
       @skip_if_blank = true
-      @links = true
-      @first_class = ''
-      @last_class = ''
-      @ul_id = ''
-      @ul_class = ''
-      @li_class = ''
-      @microdata = false
-      @last_crumb_linked = true
+      @render_with_links = true
+      @default_crumb_class = ''
+      @container_class = ''
+      @first_crumb_class = ''
+      @last_crumb_class = ''
+      @link_last_crumb = true
       @truncate = nil
-      @right_side = false
-    end
-
-    def active_li_class=(class_name)
-      puts "CRUMMY: The 'active_li_class' option is DEPRECATED and will be removed from a future version"
-    end
-
-    def active_li_class
-      puts "CRUMMY: The 'active_li_class' option is DEPRECATED and will be removed from a future version"
+      @escape = true
+      @crumb_html = {}
     end
   end
 

--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -15,7 +15,7 @@ module Crummy
         raise ArgumentError, "Need more arguments" unless name or options[:record] or block_given?
         raise ArgumentError, "Cannot pass url and use block" if url && block_given?
 
-        before_action(options) do |instance|
+        before_filter(options) do |instance|
           url = yield instance if block_given?
           url = instance.send url if url.is_a? Symbol
 
@@ -47,7 +47,7 @@ module Crummy
       end
 
       def clear_crumbs
-        before_action do |instance|
+        before_filter do |instance|
           instance.clear_crumbs
         end
       end

--- a/lib/crummy/action_controller.rb
+++ b/lib/crummy/action_controller.rb
@@ -7,7 +7,7 @@ module Crummy
       #   add_crumb(lambda { |instance| instance.business_name }, "/")
       #   add_crumb("Business") { |instance| instance.business_path }
       #
-      # Works like a before_filter so +:only+ and +except+ both work.
+      # Works like a before_action so +:only+ and +except+ both work.
       def add_crumb(name, *args)
         options = args.extract_options!
         url = args.first
@@ -15,7 +15,7 @@ module Crummy
         raise ArgumentError, "Need more arguments" unless name or options[:record] or block_given?
         raise ArgumentError, "Cannot pass url and use block" if url && block_given?
 
-        before_filter(options) do |instance|
+        before_action(options) do |instance|
           url = yield instance if block_given?
           url = instance.send url if url.is_a? Symbol
 
@@ -47,7 +47,7 @@ module Crummy
       end
 
       def clear_crumbs
-        before_filter do |instance|
+        before_action do |instance|
           instance.clear_crumbs
         end
       end

--- a/lib/crummy/action_view.rb
+++ b/lib/crummy/action_view.rb
@@ -4,18 +4,17 @@ module Crummy
     def crumbs
       @_crumbs ||= [] # Give me something to push to
     end
-    
+
     # Add a crumb to the +crumbs+ array
-    def add_crumb(name, url=nil, options={})
+    def add_crumb(name, url = nil, options = {})
       crumbs.push [name, url, options]
     end
-    
+
     # Render the list of crumbs using renderer
-    #
     def render_crumbs(options = {})
       raise ArgumentError, "Renderer and block given" if options.has_key?(:renderer) && block_given?
       return yield(crumbs, options) if block_given?
-      
+
       @_renderer ||= if options.has_key?(:renderer)
         options.delete(:renderer)
       else

--- a/lib/crummy/railtie.rb
+++ b/lib/crummy/railtie.rb
@@ -6,10 +6,10 @@ module Crummy
     initializer "crummy.action_controller" do |app|
       if defined?(ActionController)
         require 'crummy/action_controller'
-	ActionController::Base.send :include,  Crummy::ControllerMethods 
+	      ActionController::Base.send :include,  Crummy::ControllerMethods
       end
     end
-    
+
     initializer "crummy.action_view" do |app|
       require 'crummy/action_view'
       ActionView::Base.send :include, Crummy::ViewMethods

--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -104,7 +104,7 @@ module Crummy
       crumb_options = options[:crumb_options].merge(crumb_options)
 
       name = name.truncate(crumb_options[:truncate]) if crumb_options[:truncate].present?
-      name = h(name) if crumb_options[:escape]
+      name = crumb_options[:escape] == false ? name.html_safe : h(name)
 
       html_classes = []
       html_classes << options[:default_crumb_class] if options[:default_crumb_class].present?

--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -65,6 +65,10 @@ module Crummy
         crumbs.each_with_index.map{ |crumb, index|
           crumb_to_xml(crumb, index, crumbs.count, options)
         }.compact.join(options[:separator]).html_safe
+      when :json
+        crumbs.each_with_index.map{ |crumb, index|
+          crumb_to_json(crumb, index, crumbs.count, options)
+        }.to_json
       else
         raise ArgumentError, "Unknown breadcrumb output format"
       end
@@ -94,10 +98,10 @@ module Crummy
       content_tag(separator, name, href: (url && options[:render_with_links] ? url : nil))
     end
 
-    def crumb_to_xml(crumb, index, total, options)
-      name, url, options = normalize_crumb(crumb, index, total, options)
+    def crumb_to_json(crumb, index, total, options)
+      name, url, crumb_options = normalize_crumb(crumb, index, total, options)
 
-      content_tag(separator, name, href: (url && options[:render_with_links] ? url : nil))
+      { name: name, href: (url && options[:render_with_links] ? url : nil) }
     end
 
     def normalize_crumb(crumb, index, total, options)

--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -42,7 +42,6 @@ module Crummy
       options[:first_crumb_class] ||= Crummy.configuration.first_crumb_class
       options[:last_crumb_class] ||= Crummy.configuration.last_crumb_class
       options[:link_last_crumb] ||= Crummy.configuration.link_last_crumb
-      options[:container_html] ||= {}
 
       options[:crumb_options] = {}
       options[:crumb_options][:truncate] = options.delete(:truncate) || Crummy.configuration.truncate
@@ -60,7 +59,7 @@ module Crummy
         inner_html = crumbs.each_with_index.map{ |crumb, index|
           crumb_to_html_list(crumb, index, crumbs.count, options)
         }.compact.join(options[:separator]).html_safe
-        content_tag(:ul, inner_html, options[:container_html])
+        content_tag(:ul, inner_html, class: options[:container_class])
       when :xml
         crumbs.each_with_index.map{ |crumb, index|
           crumb_to_xml(crumb, index, crumbs.count, options)

--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -71,14 +71,27 @@ module Crummy
       crumb_html[:class].uniq!
       crumb_html.delete(:class) if crumb_html[:class].blank?
 
-      if url && get_option(:wrap_with).present?
-        content_tag(get_option(:wrap_with).to_sym, link_to(name, url), crumb_html)
-      elsif url
-        link_to(name, url, crumb_html)
+      if get_option(:microdata)
+        crumb_html = crumb_html.merge(itemscope: true, itemtype: data_definition_url('breadcrumb'))
+        wrap_with = get_option(:wrap_with).presence || :div
+
+        if url
+          content_tag(wrap_with.to_sym, link_to(content_tag(:span, name, itemprop: 'title'), url, itemprop: 'url'), crumb_html)
+        else
+          content_tag(wrap_with.to_sym, content_tag(:span, name, itemprop: 'title'), crumb_html)
+        end
       elsif get_option(:wrap_with).present?
-        content_tag(get_option(:wrap_with).to_sym, content_tag(:span, name), crumb_html)
+        if url
+          content_tag(get_option(:wrap_with).to_sym, link_to(content_tag(:span, name), url), crumb_html)
+        else
+          content_tag(get_option(:wrap_with).to_sym, content_tag(:span, name), crumb_html)
+        end
       else
-        content_tag(:span, name, crumb_html)
+        if url
+          link_to(content_tag(:span, name), url, crumb_html)
+        else
+          content_tag(:span, name, crumb_html)
+        end
       end
     end
 
@@ -114,6 +127,10 @@ module Crummy
 
     def get_option(option)
       self.options.fetch(option, Crummy.configuration.send(option.to_sym)).clone
+    end
+
+    def data_definition_url(type)
+      "http://data-vocabulary.org/#{type}"
     end
   end
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 2
   MINOR = 1
-  PATCH  = 3
+  PATCH  = 4
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 2
   MINOR = 1
-  PATCH  = 0
+  PATCH  = 1
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 2
-  MINOR = 0
-  PATCH  = 1
+  MINOR = 1
+  PATCH  = 0
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 2
   MINOR = 1
-  PATCH  = 2
+  PATCH  = 3
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
-  MAJOR = 1
-  MINOR = 8
+  MAJOR = 2
+  MINOR = 0
   PATCH  = 0
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 2
   MINOR = 0
-  PATCH  = 0
+  PATCH  = 1
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 2
   MINOR = 1
-  PATCH  = 1
+  PATCH  = 2
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -15,19 +15,19 @@ class StandardRendererTest < Minitest::Test
 
   def test_classes
     renderer = StandardRenderer.new
-    assert_dom_equal('<a href="url" class="default first last">name</a>',
+    assert_dom_equal('<a href="url" class="default first last"><span>name</span></a>',
                  renderer.render_crumbs([['name', 'url']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :html))
 
-    assert_dom_equal('<ul><li class="default first last"><a href="url">name</a></li></ul>',
+    assert_dom_equal('<ul><li class="default first last"><a href="url"><span>name</span></a></li></ul>',
                  renderer.render_crumbs([['name', 'url']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', container: :ul, wrap_with: :li, separator: nil, format: :html))
 
     assert_dom_equal('<crumbs><crumb href="url">name</crumb></crumbs>',
                  renderer.render_crumbs([['name', 'url']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :xml))
 
-    assert_dom_equal('<a href="url1" class="default first">name1</a> &raquo; <a href="url2" class="default">name2</a> &raquo; <a href="url3" class="default last">name3</a>',
+    assert_dom_equal('<a href="url1" class="default first"><span>name1</span></a> &raquo; <a href="url2" class="default"><span>name2</span></a> &raquo; <a href="url3" class="default last"><span>name3</span></a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :html))
 
-    assert_dom_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li><li class="default"><a href="url2">name2</a></li><li class="default last"><a href="url3">name3</a></li></ul>',
+    assert_dom_equal('<ul class="container"><li class="default first"><a href="url1"><span>name1</span></a></li><li class="default"><a href="url2"><span>name2</span></a></li><li class="default last"><a href="url3"><span>name3</span></a></li></ul>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', container_class: 'container', container: :ul, wrap_with: :li, separator: nil, format: :html))
 
     assert_dom_equal('<crumbs><crumb href="url1">name1</crumb><crumb href="url2">name2</crumb></crumbs>',
@@ -45,10 +45,10 @@ class StandardRendererTest < Minitest::Test
     assert_dom_equal('<crumbs><crumb>name</crumb></crumbs>',
                  renderer.render_crumbs([['name', 'url']], format: :xml, link_last_crumb: false))
 
-    assert_dom_equal('<a href="url1">name1</a> &raquo; <span>name2</span>',
+    assert_dom_equal('<a href="url1"><span>name1</span></a> &raquo; <span>name2</span>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], format: :html, link_last_crumb: false))
 
-    assert_dom_equal('<ul><li><a href="url1">name1</a></li><li><a href="url2">name2</a></li><li><span>name3</span></li></ul>',
+    assert_dom_equal('<ul><li><a href="url1"><span>name1</span></a></li><li><a href="url2"><span>name2</span></a></li><li><span>name3</span></li></ul>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], container: :ul, wrap_with: :li, separator: nil, format: :html, link_last_crumb: false))
 
     assert_dom_equal('<crumbs><crumb href="url1">name1</crumb><crumb>name2</crumb></crumbs>',
@@ -75,17 +75,40 @@ class StandardRendererTest < Minitest::Test
   def test_html_options
     renderer = StandardRenderer.new
 
-    assert_dom_equal('<a href="url" title="title">name</a>',
+    assert_dom_equal('<a href="url" title="title"><span>name</span></a>',
                  renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], format: :html))
 
     assert_dom_equal('<span title="title">name</span>',
                  renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], format: :html, link_last_crumb: false))
 
-    assert_dom_equal('<ul><li title="title"><a href="url">name</a></li></ul>',
+    assert_dom_equal('<ul><li title="title"><a href="url"><span>name</span></a></li></ul>',
                  renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], container: :ul, wrap_with: :li, separator: nil, format: :html))
 
     assert_dom_equal('<ul><li title="title"><span>name</span></li></ul>',
                  renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], container: :ul, wrap_with: :li, format: :html, link_last_crumb: false))
+  end
+
+  def test_link_html_options_with_microdata
+    renderer = StandardRenderer.new
+    Crummy.configure do |config|
+      config.microdata = true
+    end
+
+    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/breadcrumb" title="title" class="first last"><a href="url" itemprop="url"><span itemprop="title">name</span></a></div>',
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], first_crumb_class: 'first', last_crumb_class: 'last', format: :html))
+
+    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/breadcrumb" title="title" class="first last"><span itemprop="title">name</span></div>',
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], first_crumb_class: 'first', last_crumb_class: 'last', format: :html, link_last_crumb: false))
+
+    assert_dom_equal('<ul><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/breadcrumb" title="title"><a itemprop="url" href="url"><span itemprop="title">name</span></a></li></ul>',
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], first_crumb_class: 'first', last_crumb_class: 'last', format: :html, container: :ul, wrap_with: :li, separator: nil))
+
+    assert_dom_equal('<ul><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/breadcrumb" title="title"><span itemprop="title">name</span></li></ul>',
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], first_crumb_class: 'first', last_crumb_class: 'last', format: :html, container: :ul, wrap_with: :li, separator: nil, link_last_crumb: false))
+
+    Crummy.configure do |config|
+      config.microdata = false
+    end
   end
 
   def test_inline_configuration

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -16,35 +16,43 @@ class StandardRendererTest < Minitest::Test
   def test_classes
     renderer = StandardRenderer.new
     assert_dom_equal('<a href="url" class="default first last">name</a>',
-                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
-    assert_dom_equal('<ul class=""><li class="default first last"><a href="url">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container => :ul, :wrap_with => :li, :format => :html))
-    assert_dom_equal('<crumb href="url">name</crumb>',
-                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
+                 renderer.render_crumbs([['name', 'url']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :html))
+
+    assert_dom_equal('<ul><li class="default first last"><a href="url">name</a></li></ul>',
+                 renderer.render_crumbs([['name', 'url']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', container: :ul, wrap_with: :li, separator: nil, format: :html))
+
+    assert_dom_equal('<crumbs><crumb href="url">name</crumb></crumbs>',
+                 renderer.render_crumbs([['name', 'url']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :xml))
 
     assert_dom_equal('<a href="url1" class="default first">name1</a> &raquo; <a href="url2" class="default">name2</a> &raquo; <a href="url3" class="default last">name3</a>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :html))
+
     assert_dom_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li><li class="default"><a href="url2">name2</a></li><li class="default last"><a href="url3">name3</a></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :container => :ul, :wrap_with => :li, :format => :html))
-    assert_dom_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', container_class: 'container', container: :ul, wrap_with: :li, separator: nil, format: :html))
+
+    assert_dom_equal('<crumbs><crumb href="url1">name1</crumb><crumb href="url2">name2</crumb></crumbs>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], default_crumb_class: 'default', first_crumb_class: 'first', last_crumb_class: 'last', format: :xml))
   end
 
-  def test_classes_last_crumb_not_linked
+  def test_last_crumb_not_linked
     renderer = StandardRenderer.new
     assert_dom_equal('<span>name</span>',
-                 renderer.render_crumbs([['name', 'url']], :format => :html, :link_last_crumb => false))
+                 renderer.render_crumbs([['name', 'url']], format: :html, link_last_crumb: false))
+
     assert_dom_equal('<ul><li><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :format => :html_list, :link_last_crumb => false))
-    assert_dom_equal('<crumb>name</crumb>',
-                 renderer.render_crumbs([['name', 'url']], :format => :xml, :link_last_crumb => false))
+                 renderer.render_crumbs([['name', 'url']], container: :ul, wrap_with: :li, separator: nil, format: :html, link_last_crumb: false))
+
+    assert_dom_equal('<crumbs><crumb>name</crumb></crumbs>',
+                 renderer.render_crumbs([['name', 'url']], format: :xml, link_last_crumb: false))
 
     assert_dom_equal('<a href="url1">name1</a> &raquo; <span>name2</span>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :html, :link_last_crumb => false))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], format: :html, link_last_crumb: false))
+
     assert_dom_equal('<ul><li><a href="url1">name1</a></li><li><a href="url2">name2</a></li><li><span>name3</span></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
-    assert_dom_equal('<crumb href="url1">name1</crumb><crumb>name2</crumb>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :xml, :link_last_crumb => false))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], container: :ul, wrap_with: :li, separator: nil, format: :html, link_last_crumb: false))
+
+    assert_dom_equal('<crumbs><crumb href="url1">name1</crumb><crumb>name2</crumb></crumbs>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], format: :xml, link_last_crumb: false))
   end
 
   def test_input_object_mutation
@@ -55,7 +63,7 @@ class StandardRendererTest < Minitest::Test
     name2 = 'name2'
     url2 = nil
 
-    renderer.render_crumbs([[name1, url1], [name2, url2]], :format => :html, :microdata => false)
+    renderer.render_crumbs([[name1, url1], [name2, url2]], format: :html, microdata: false)
 
     # Rendering the crumbs shouldn't alter the input objects.
     assert_equal('name1', name1);
@@ -68,16 +76,16 @@ class StandardRendererTest < Minitest::Test
     renderer = StandardRenderer.new
 
     assert_dom_equal('<a href="url" title="title">name</a>',
-                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html))
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], format: :html))
 
     assert_dom_equal('<span title="title">name</span>',
-                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html, :link_last_crumb => false))
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], format: :html, link_last_crumb: false))
 
     assert_dom_equal('<ul><li title="title"><a href="url">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :container => :ul, :wrap_with => :li, :format => :html))
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], container: :ul, wrap_with: :li, separator: nil, format: :html))
 
     assert_dom_equal('<ul><li title="title"><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}]], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
+                 renderer.render_crumbs([['name', 'url', crumb_html: { title: 'title' }]], container: :ul, wrap_with: :li, format: :html, link_last_crumb: false))
   end
 
   def test_inline_configuration
@@ -86,15 +94,19 @@ class StandardRendererTest < Minitest::Test
       config.link_last_crumb = true
     end
 
-    refute_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
-    assert_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => true))
+    refute_match(/href/, renderer.render_crumbs([['name', 'url']], link_last_crumb: false))
+    assert_match(/href/, renderer.render_crumbs([['name', 'url']], link_last_crumb: true))
 
     Crummy.configure do |config|
       config.link_last_crumb = false
     end
 
-    refute_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
-    assert_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => true))
+    refute_match(/href/, renderer.render_crumbs([['name', 'url']], link_last_crumb: false))
+    assert_match(/href/, renderer.render_crumbs([['name', 'url']], link_last_crumb: true))
+
+    Crummy.configure do |config|
+      config.link_last_crumb = true
+    end
   end
 
   def test_configuration
@@ -106,5 +118,8 @@ class StandardRendererTest < Minitest::Test
       config.separator = " / "
     end
     assert_equal " / ", Crummy.configuration.separator
+    Crummy.configure do |config|
+      config.separator = " &raquo; "
+    end
   end
 end

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -18,16 +18,14 @@ class StandardRendererTest < Test::Unit::TestCase
     assert_equal('<a href="url" class="default first last">name</a>',
                  renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
     assert_equal('<ul class=""><li class="default first last"><a href="url">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html_list))
+                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container => :ul, :wrap_with => :li, :format => :html))
     assert_equal('<crumb href="url">name</crumb>',
                  renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
 
     assert_equal('<a href="url1" class="default first">name1</a> &raquo; <a href="url2" class="default">name2</a> &raquo; <a href="url3" class="default last">name3</a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
     assert_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li><li class="default"><a href="url2">name2</a></li><li class="default last"><a href="url3">name3</a></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :format => :html_list))
-    assert_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li> / <li class="default"><a href="url2">name2</a></li> / <li class="default last"><a href="url3">name3</a></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :format => :html_list, :separator => ' / '))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :container => :ul, :wrap_with => :li, :format => :html))
     assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
   end
@@ -44,9 +42,7 @@ class StandardRendererTest < Test::Unit::TestCase
     assert_equal('<a href="url1">name1</a> &raquo; <span>name2</span>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :html, :link_last_crumb => false))
     assert_equal('<ul><li><a href="url1">name1</a></li><li><a href="url2">name2</a></li><li><span>name3</span></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :format => :html_list, :link_last_crumb => false))
-    assert_equal('<ul><li><a href="url1">name1</a></li><li> / </li><li><a href="url2">name2</a></li><li> / </li><li><span>name3</span></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :format => :html_list, :separator => ' / ', :link_last_crumb => false))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
     assert_equal('<crumb href="url1">name1</crumb><crumb>name2</crumb>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :xml, :link_last_crumb => false))
   end
@@ -78,10 +74,10 @@ class StandardRendererTest < Test::Unit::TestCase
                  renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html, :link_last_crumb => false))
 
     assert_equal('<ul><li title="title"><a href="url">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html_list))
+                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :container => :ul, :wrap_with => :li, :format => :html))
 
     assert_equal('<ul><li title="title"><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}}]], :format => :html_list, :link_last_crumb => false))
+                 renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}}]], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
   end
 
   def test_inline_configuration

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -77,7 +77,7 @@ class StandardRendererTest < Test::Unit::TestCase
                  renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :container => :ul, :wrap_with => :li, :format => :html))
 
     assert_equal('<ul><li title="title"><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}}]], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
+                 renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}]], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
   end
 
   def test_inline_configuration

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'bundler'
 Bundler.require(:test)
-require 'test/unit'
+require 'minitest/autorun'
 
 require 'action_controller'
 require 'active_support/core_ext/string/output_safety'
@@ -9,41 +9,41 @@ require 'action_dispatch/testing/assertions'
 require 'crummy'
 require 'crummy/standard_renderer'
 
-class StandardRendererTest < Test::Unit::TestCase
-  include ActionDispatch::Assertions::DomAssertions
+class StandardRendererTest < Minitest::Test
+  include ActionDispatch::Assertions
   include Crummy
 
   def test_classes
     renderer = StandardRenderer.new
-    assert_equal('<a href="url" class="default first last">name</a>',
+    assert_dom_equal('<a href="url" class="default first last">name</a>',
                  renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
-    assert_equal('<ul class=""><li class="default first last"><a href="url">name</a></li></ul>',
+    assert_dom_equal('<ul class=""><li class="default first last"><a href="url">name</a></li></ul>',
                  renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container => :ul, :wrap_with => :li, :format => :html))
-    assert_equal('<crumb href="url">name</crumb>',
+    assert_dom_equal('<crumb href="url">name</crumb>',
                  renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
 
-    assert_equal('<a href="url1" class="default first">name1</a> &raquo; <a href="url2" class="default">name2</a> &raquo; <a href="url3" class="default last">name3</a>',
+    assert_dom_equal('<a href="url1" class="default first">name1</a> &raquo; <a href="url2" class="default">name2</a> &raquo; <a href="url3" class="default last">name3</a>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
-    assert_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li><li class="default"><a href="url2">name2</a></li><li class="default last"><a href="url3">name3</a></li></ul>',
+    assert_dom_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li><li class="default"><a href="url2">name2</a></li><li class="default last"><a href="url3">name3</a></li></ul>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :container => :ul, :wrap_with => :li, :format => :html))
-    assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
+    assert_dom_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
   end
 
   def test_classes_last_crumb_not_linked
     renderer = StandardRenderer.new
-    assert_equal('<span>name</span>',
+    assert_dom_equal('<span>name</span>',
                  renderer.render_crumbs([['name', 'url']], :format => :html, :link_last_crumb => false))
-    assert_equal('<ul><li><span>name</span></li></ul>',
+    assert_dom_equal('<ul><li><span>name</span></li></ul>',
                  renderer.render_crumbs([['name', 'url']], :format => :html_list, :link_last_crumb => false))
-    assert_equal('<crumb>name</crumb>',
+    assert_dom_equal('<crumb>name</crumb>',
                  renderer.render_crumbs([['name', 'url']], :format => :xml, :link_last_crumb => false))
 
-    assert_equal('<a href="url1">name1</a> &raquo; <span>name2</span>',
+    assert_dom_equal('<a href="url1">name1</a> &raquo; <span>name2</span>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :html, :link_last_crumb => false))
-    assert_equal('<ul><li><a href="url1">name1</a></li><li><a href="url2">name2</a></li><li><span>name3</span></li></ul>',
+    assert_dom_equal('<ul><li><a href="url1">name1</a></li><li><a href="url2">name2</a></li><li><span>name3</span></li></ul>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
-    assert_equal('<crumb href="url1">name1</crumb><crumb>name2</crumb>',
+    assert_dom_equal('<crumb href="url1">name1</crumb><crumb>name2</crumb>',
                  renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :xml, :link_last_crumb => false))
   end
 
@@ -67,16 +67,16 @@ class StandardRendererTest < Test::Unit::TestCase
   def test_html_options
     renderer = StandardRenderer.new
 
-    assert_equal('<a href="url" title="title">name</a>',
+    assert_dom_equal('<a href="url" title="title">name</a>',
                  renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html))
 
-    assert_equal('<span title="title">name</span>',
+    assert_dom_equal('<span title="title">name</span>',
                  renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html, :link_last_crumb => false))
 
-    assert_equal('<ul><li title="title"><a href="url">name</a></li></ul>',
+    assert_dom_equal('<ul><li title="title"><a href="url">name</a></li></ul>',
                  renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :container => :ul, :wrap_with => :li, :format => :html))
 
-    assert_equal('<ul><li title="title"><span>name</span></li></ul>',
+    assert_dom_equal('<ul><li title="title"><span>name</span></li></ul>',
                  renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}]], :container => :ul, :wrap_with => :li, :format => :html, :link_last_crumb => false))
   end
 
@@ -86,25 +86,25 @@ class StandardRendererTest < Test::Unit::TestCase
       config.link_last_crumb = true
     end
 
-    assert_no_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
+    refute_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
     assert_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => true))
 
     Crummy.configure do |config|
       config.link_last_crumb = false
     end
 
-    assert_no_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
+    refute_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
     assert_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => true))
   end
 
   def test_configuration
     renderer = StandardRenderer.new
     # check defaults
-    assert_equal " &raquo; ", Crummy.configuration.html_separator
+    assert_equal " &raquo; ", Crummy.configuration.separator
     # adjust configuration
     Crummy.configure do |config|
-      config.html_separator = " / "
+      config.separator = " / "
     end
-    assert_equal " / ", Crummy.configuration.html_separator
+    assert_equal " / ", Crummy.configuration.separator
   end
 end

--- a/test/standard_renderer_test.rb
+++ b/test/standard_renderer_test.rb
@@ -15,61 +15,44 @@ class StandardRendererTest < Test::Unit::TestCase
 
   def test_classes
     renderer = StandardRenderer.new
-    assert_dom_equal('<a href="url" class="first last">name</a>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html))
-    assert_equal('<ul class=""><li class="first last"><a href="url">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list))
+    assert_equal('<a href="url" class="default first last">name</a>',
+                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
+    assert_equal('<ul class=""><li class="default first last"><a href="url">name</a></li></ul>',
+                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html_list))
     assert_equal('<crumb href="url">name</crumb>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :xml))
+                 renderer.render_crumbs([['name', 'url']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
 
-    assert_dom_equal('<a href="url1" class="first">name1</a> &raquo; <a href="url2" class="last">name2</a>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html))
-    assert_equal('<ul class=""><li class="first li_class"><a href="url1">name1</a></li><li class="li_class"><a href="url2">name2</a></li><li class="last li_class"><a href="url3">name3</a></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list))
-    assert_equal('<ul class=""><li class="first li_class"><a href="url1">name1</a></li><li> / </li><li class="li_class"><a href="url2">name2</a></li><li> / </li><li class="last li_class"><a href="url3">name3</a></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list, :separator => " / "))
+    assert_equal('<a href="url1" class="default first">name1</a> &raquo; <a href="url2" class="default">name2</a> &raquo; <a href="url3" class="default last">name3</a>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :html))
+    assert_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li><li class="default"><a href="url2">name2</a></li><li class="default last"><a href="url3">name3</a></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :format => :html_list))
+    assert_equal('<ul class="container"><li class="default first"><a href="url1">name1</a></li> / <li class="default"><a href="url2">name2</a></li> / <li class="default last"><a href="url3">name3</a></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :container_class => 'container', :format => :html_list, :separator => ' / '))
     assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :xml))
-
-    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :microdata => true))
-    assert_equal('<ul class=""><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" itemprop="url"><span itemprop="title">name</span></a></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list, :microdata => true))
-    assert_equal('<ul class="crumbclass" id="crumbid"><li class="liclass"><a href="url">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :format => :html_list, :ul_id => "crumbid", :ul_class => "crumbclass", :li_class => "liclass"))
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :default_crumb_class => 'default', :first_crumb_class => 'first', :last_crumb_class => 'last', :format => :xml))
   end
- 
+
   def test_classes_last_crumb_not_linked
     renderer = StandardRenderer.new
-    assert_equal('name',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
-    assert_equal('<ul class=""><li class="first last"><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
-    assert_equal('<crumb href="url">name</crumb>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :xml, :last_crumb_linked => false))
+    assert_equal('<span>name</span>',
+                 renderer.render_crumbs([['name', 'url']], :format => :html, :link_last_crumb => false))
+    assert_equal('<ul><li><span>name</span></li></ul>',
+                 renderer.render_crumbs([['name', 'url']], :format => :html_list, :link_last_crumb => false))
+    assert_equal('<crumb>name</crumb>',
+                 renderer.render_crumbs([['name', 'url']], :format => :xml, :link_last_crumb => false))
 
-    assert_dom_equal('<a href="url1" class="first">name1</a> &raquo; name2',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
-    assert_equal('<ul class=""><li class="first li_class"><a href="url1">name1</a></li><li class="li_class"><a href="url2">name2</a></li><li class="last li_class"><span>name3</span></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
-    assert_equal('<ul class=""><li class="first li_class"><a href="url1">name1</a></li><li> / </li><li class="li_class"><a href="url2">name2</a></li><li> / </li><li class="last li_class"><span>name3</span></li></ul>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :li_class => "li_class", :first_class => 'first', :last_class => 'last', :format => :html_list, :separator => " / ", :last_crumb_linked => false))
-    assert_equal('<crumb href="url1">name1</crumb><crumb href="url2">name2</crumb>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :first_class => 'first', :last_class => 'last', :format => :xml, :last_crumb_linked => false))
-
-    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></div>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :microdata => true, :last_crumb_linked => false))
-    assert_equal('<ul class=""><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html_list, :microdata => true, :last_crumb_linked => false))
-    assert_equal('<ul class="crumbclass" id="crumbid"><li class="liclass"><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url']], :format => :html_list, :ul_id => "crumbid", :ul_class => "crumbclass", :li_class => "liclass", :last_crumb_linked => false))
+    assert_equal('<a href="url1">name1</a> &raquo; <span>name2</span>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :html, :link_last_crumb => false))
+    assert_equal('<ul><li><a href="url1">name1</a></li><li><a href="url2">name2</a></li><li><span>name3</span></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :format => :html_list, :link_last_crumb => false))
+    assert_equal('<ul><li><a href="url1">name1</a></li><li> / </li><li><a href="url2">name2</a></li><li> / </li><li><span>name3</span></li></ul>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2'], ['name3', 'url3']], :format => :html_list, :separator => ' / ', :link_last_crumb => false))
+    assert_equal('<crumb href="url1">name1</crumb><crumb>name2</crumb>',
+                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :format => :xml, :link_last_crumb => false))
   end
 
   def test_input_object_mutation
     renderer = StandardRenderer.new
-    Crummy.configure do |config|
-      config.microdata = false
-    end
 
     name1 = 'name1'
     url1 = nil
@@ -85,61 +68,37 @@ class StandardRendererTest < Test::Unit::TestCase
     assert_equal(nil, url2);
   end
 
-  def test_link_html_options
+  def test_html_options
     renderer = StandardRenderer.new
-    Crummy.configure do |config|
-      config.microdata = false
-    end
 
-    assert_dom_equal('<a href="url" class="first last" title="link title">name</a>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html))
+    assert_equal('<a href="url" title="title">name</a>',
+                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html))
 
-    assert_equal('name',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
+    assert_equal('<span title="title">name</span>',
+                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html, :link_last_crumb => false))
 
-    assert_equal('<ul class=""><li class="first last"><a href="url" title="link title">name</a></li></ul>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html_list))
+    assert_equal('<ul><li title="title"><a href="url">name</a></li></ul>',
+                 renderer.render_crumbs([['name', 'url', :html => { :title => 'title' }]], :format => :html_list))
 
-    assert_equal('<ul class=""><li class="first last"><span>name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
-  end
-
-  def test_link_html_options_with_microdata
-    renderer = StandardRenderer.new
-    Crummy.configure do |config|
-      config.microdata = true
-    end
-
-    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url" title="link title"><span itemprop="title">name</span></a></div>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html))
-
-    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></div>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
-
-    assert_equal('<ul class=""><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" itemprop="url" title="link title"><span itemprop="title">name</span></a></li></ul>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html_list))
-
-    assert_equal('<ul class=""><li class="first last" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></li></ul>',
-                 renderer.render_crumbs([['name', 'url', {:link_html_options => {:title => 'link title'}}]], :first_class => 'first', :last_class => 'last', :format => :html_list, :last_crumb_linked => false))
+    assert_equal('<ul><li title="title"><span>name</span></li></ul>',
+                 renderer.render_crumbs([['name', 'url', :html_options => {:title => 'link title'}}]], :format => :html_list, :link_last_crumb => false))
   end
 
   def test_inline_configuration
     renderer = StandardRenderer.new
     Crummy.configure do |config|
-      config.microdata = true
-      config.last_crumb_linked = true
+      config.link_last_crumb = true
     end
 
-    assert_no_match(/itemscope/, renderer.render_crumbs([['name', 'url']], :microdata => false))
-    assert_match(/href/, renderer.render_crumbs([['name', 'url']], :last_crumb_linked => true))
+    assert_no_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
+    assert_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => true))
 
     Crummy.configure do |config|
-      config.microdata = false
-      config.last_crumb_linked = true
+      config.link_last_crumb = false
     end
 
-    assert_match(/itemscope/, renderer.render_crumbs([['name', 'url']], :microdata => true))
-    assert_no_match(/href/, renderer.render_crumbs([['name', 'url']], :last_crumb_linked => false))
+    assert_no_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => false))
+    assert_match(/href/, renderer.render_crumbs([['name', 'url']], :link_last_crumb => true))
   end
 
   def test_configuration
@@ -152,31 +111,4 @@ class StandardRendererTest < Test::Unit::TestCase
     end
     assert_equal " / ", Crummy.configuration.html_separator
   end
-
-  def test_configured_renderer
-    renderer = StandardRenderer.new
-    Crummy.configure do |config|
-      config.html_separator = " / "
-    end
-    # using configured separator
-    assert_dom_equal('<a href="url1" class="">name1</a> / <a href="url2" class="">name2</a>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']]))
-    # overriding configured separator
-    assert_dom_equal('<a href="url1" class="">name1</a> | <a href="url2" class="">name2</a>',
-                 renderer.render_crumbs([['name1', 'url1'], ['name2', 'url2']], :separator => " | "))
-  end
-
-  def test_configured_renderer_with_microdata
-    renderer = StandardRenderer.new
-    Crummy.configure do |config|
-      config.microdata = true
-    end
-    # using configured microdata setting
-    assert_dom_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="url" class="first last" itemprop="url"><span itemprop="title">name</span></a></div>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html))
-    # last crumb not linked
-    assert_equal('<div itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">name</span></div>',
-                 renderer.render_crumbs([['name', 'url']], :first_class => 'first', :last_class => 'last', :format => :html, :last_crumb_linked => false))
-  end
-
 end


### PR DESCRIPTION
I've made quite a few changes and improvements to Crummy. Most notably is a fix to a XSS bug that occurs if your crumb's name is derived from user-entered data. Adding html_safe to strings so liberally is bad.

In the process of making these changes I did drop the microdata support due to the spec being abandoned. I didn't have much need or desire to implement the new spec.

Here's a run-down of what has changed. Pick and choose as you wish.
- Replace local_global lambda with better options hash and merge
- Reduce arguments on crumb_to methods by passing options hash
- Rails convention is to html_escape unless explicitely stated by using html_safe so name is now always escaped. This fixes a gaping XSS vulnerability
- Common crumb_to logic moved to another method
- Normalized configuration option names
- Right-to-left crumbs now behave the same across all formats
- Passing :html hash to add_crumb now allows you to add any attributes you want. Default atrtributes can be set with the crumb_html configuration option.
- Common name of 'separator' when doing in-line configuration
- Cleaned up trailing whitespace
- Bumped version to 2.0.0 as these changes are not backwards compatible.
- Updated tests
